### PR TITLE
Fix wrong url matching

### DIFF
--- a/tinchy.py
+++ b/tinchy.py
@@ -28,7 +28,7 @@ def index():
 @bottle.post('/')
 def make_tinchy_url():
     fatty_url = bottle.request.POST.get('url', '')
-    if fatty_url[:24] == 'http://talk.manageiq.org' or fatty_url[:25] == 'https://talk.manageiq.org':
+    if fatty_url[:25] == 'http://talk.manageiq.org/' or fatty_url[:26] == 'https://talk.manageiq.org/':
         storage = shelve.open('tinchy')
         tinchy_id = generate_tinchy_id()
         while tinchy_id in storage:


### PR DESCRIPTION
Since the url code do not check the final /, a user could try to
shorten http://talk.manageiq.org:foo@someserver.example.com/ and
it would be accepted, which is not what we want.